### PR TITLE
フェンダーの説明の追加

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ literal>`_ list, then that takes precedence and underscores in the
 _`<pattern>`_ match as literals.  Multiple underscores can appear in a
 _`<pattern>`_.
 
-Identifiers that appear in `(_<pattern literal>`_ ...)` are interpreted as
+Identifiers that appear in `(_<pattern literal>_ ...)` are interpreted as
 literal identifiers to be matched against corresponding elements of the
 input.  An element in the input matches a literal identifiers if and only
 if it is an symbol and equal to literal identifier in the sense of the

--- a/readme.md
+++ b/readme.md
@@ -18,12 +18,12 @@ A `pattern-match-lambda`'s syntax is the following.
 (pattern-match-lambda (<pattern literal> ...) <clause> ...)
 ```
 
-<clause> must have one of the following forms:
+_<clause>_ must have one of the following forms:
 
 - ```(<pattern> <expr>)```
 - ```(<pattern> <fender> <expr>)```
 
-A <pattern> is either an identifier, a constant, or one of the followings.
+A _<pattern>_ is either an identifier, a constant, or one of the followings.
 
 ```scheme
 (<pattern> ...)
@@ -31,8 +31,8 @@ A <pattern> is either an identifier, a constant, or one of the followings.
 #(<pattern> ...)
 ```
 
-A <fender> is an expression which is evaluated when <pattern> is matched.
-If the result of evaluation is true value, then the following <expr> is
+A _<fender>_ is an expression which is evaluated when _<pattern>_ is matched.
+If the result of evaluation is true value, then the following _<expr>_ is
 evaluated, otherwise `pattern-match-lambda` continues matching. The following
 example shows how it works:
 
@@ -51,32 +51,32 @@ example shows how it works:
 A `pattern-match-lambda` expression evaluates to a procedure that accepts a
 variable number of arguments and is lexically scoped in the same manner as 
 a procedure resulting from a lambda expression. When the procedure is called,
-the first <clause> for which the arguments match with <pattern> is selected, 
-where argument is specified as for the <pattern> of a syntax-rules like 
-expression.
+the first _<clause>_ for which the arguments match with _<pattern>_ is 
+selected, where argument is specified as for the _<pattern>_ of a 
+syntax-rules like expression.
 
-Difference between <pattern> of `syntax-rules` and `pattern-match-lambda` is 
-ellipsis. Ellipsis is not able to use in pattern-match-lambda's <pattern>.
+Difference between _<pattern>_ of `syntax-rules` and `pattern-match-lambda` is 
+ellipsis. Ellipsis is not able to use in pattern-match-lambda's _<pattern>_.
 
-The variables of <pattern> are bound to fresh locations, the values of the 
-arguments are stored in those locations, the <body> is evaluated in the 
-extended environment, and the results of <body> are returned as the results 
+The variables of _<pattern>_ are bound to fresh locations, the values of the 
+arguments are stored in those locations, the _<body>_ is evaluated in the 
+extended environment, and the results of _<body>_ are returned as the results 
 of the procedure call. It is an error for the arguments not to match with 
-the <pattern> of any <clause>.
+the _<pattern>_ of any _<clause>_.
 
-An identifier appearing within a <pattern> can be an underscore (`_`), a 
-literal identifier listed in the list of <pattern-literal>. All other 
-identifiers appearing within a <pattern> are variables.
+An identifier appearing within a _<pattern>_ can be an underscore (`_`), a 
+literal identifier listed in the list of _<pattern-literal>_. All other 
+identifiers appearing within a _<pattern>_ are variables.
 
-Variables in <pattern> match arbitrary input elements and are used to refer 
+Variables in _<pattern>_ match arbitrary input elements and are used to refer 
 to elements of the input in the body. It is an error for the same variable 
-to appear more than once in a <pattern>. Underscores also match arbitrary 
+to appear more than once in a _<pattern>_. Underscores also match arbitrary 
 input elements but are not variables and so cannot be used to refer to those 
-elements. If an underscore appears in the <pattern literal> list, then that 
-takes precedence and underscores in the <pattern> match as literals. Multiple 
-underscores can appear in a <pattern>.
+elements. If an underscore appears in the _<pattern literal>_ list, then that 
+takes precedence and underscores in the _<pattern>_ match as literals. Multiple 
+underscores can appear in a _<pattern>_.
 
-Identifiers that appear in (<pattern literal> ...) are interpreted as literal 
+Identifiers that appear in (_<pattern literal>_ ...) are interpreted as literal 
 identifiers to be matched against corresponding elements of the input. An 
 element in the input matches a literal identifiers if and only if it is an 
 symbol and equal to literal identifier in the sense of the eqv? procedure.

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,23 @@ The `pattern-match-lambda`'s syntax is the following.
 (pattern-match-lambda (<pattern literal> ...) <clause> ...)
 ```
 
+`(_<pattern literal>_ ...)` must be either null or a list of unique
+identifiers. If this is not null, then specified identifiers are treated as
+if they are keyword of the `pattern-match-lambda` macro.
+
+```scheme
+(define literal
+  (pattern-match-lambda (foo)
+    ((foo x) x)
+    ((_   x) 'ng)))
+
+(literal 'foo 'x) ;; -> x
+(literal 'bar 'x) ;; -> ng
+```
+
+Literal matching are done against mere symbols not syntax identifiers. This
+is because `pattern-match-lambda` macro creates an procedure not a macro.
+
 _`<clause>`_ must have one of the following forms:
 
 - ```(<pattern> <expr>)```

--- a/readme.md
+++ b/readme.md
@@ -2,14 +2,14 @@
 
 ## Introduction
 
-This package is easy pattern match library for R7RS.
-It provides only one macro named `pattern-match-lambda`.
+This package is easy pattern match library for R7RS.  It provides only one
+macro named `pattern-match-lambda`.
 
 ## Install
 
-This package doesn't contain install scripts.
-The installation procedure depends on the Scheme implementation you're using.
-Please see document of the implementation.
+This package doesn't contain install scripts.  The installation procedure
+depends on the Scheme implementation you're using.  Please see document of
+the implementation.
 
 ## Syntax
 A `pattern-match-lambda`'s syntax is the following.
@@ -18,12 +18,13 @@ A `pattern-match-lambda`'s syntax is the following.
 (pattern-match-lambda (<pattern literal> ...) <clause> ...)
 ```
 
-_<clause>_ must have one of the following forms:
+_`<clause>`_ must have one of the following forms:
 
 - ```(<pattern> <expr>)```
 - ```(<pattern> <fender> <expr>)```
 
-A _<pattern>_ is either an identifier, a constant, or one of the followings.
+A _`<pattern>`_ is either an identifier, a constant, or one of the
+followings.
 
 ```scheme
 (<pattern> ...)
@@ -31,10 +32,10 @@ A _<pattern>_ is either an identifier, a constant, or one of the followings.
 #(<pattern> ...)
 ```
 
-A _<fender>_ is an expression which is evaluated when _<pattern>_ is matched.
-If the result of evaluation is true value, then the following _<expr>_ is
-evaluated, otherwise `pattern-match-lambda` continues matching. The following
-example shows how it works:
+A _`<fender>`_ is an expression which is evaluated when _`<pattern>`_ is
+matched.  If the result of evaluation is true value, then the following
+_`<expr>`_ is evaluated, otherwise `pattern-match-lambda` continues
+matching. The following example shows how it works:
 
 ```scheme
 (define foo
@@ -49,43 +50,46 @@ example shows how it works:
 ## Semantics
 
 A `pattern-match-lambda` expression evaluates to a procedure that accepts a
-variable number of arguments and is lexically scoped in the same manner as 
-a procedure resulting from a lambda expression. When the procedure is called,
-the first _<clause>_ for which the arguments match with _<pattern>_ is 
-selected, where argument is specified as for the _<pattern>_ of a 
-syntax-rules like expression.
+variable number of arguments and is lexically scoped in the same manner as
+a procedure resulting from a lambda expression. When the procedure is
+called, the first _`<clause>`_ for which the arguments match with
+_`<pattern>`_ is selected, where argument is specified as for the
+_`<pattern>`_ of a syntax-rules like expression.
 
-Difference between _<pattern>_ of `syntax-rules` and `pattern-match-lambda` is 
-ellipsis. Ellipsis is not able to use in pattern-match-lambda's _<pattern>_.
+Difference between _`<pattern>`_ of `syntax-rules` and
+`pattern-match-lambda` is ellipsis. Ellipsis is not able to use in
+pattern-match-lambda's _`<pattern>`_.
 
-The variables of _<pattern>_ are bound to fresh locations, the values of the 
-arguments are stored in those locations, the _<body>_ is evaluated in the 
-extended environment, and the results of _<body>_ are returned as the results 
-of the procedure call. It is an error for the arguments not to match with 
-the _<pattern>_ of any _<clause>_.
+The variables of _`<pattern>`_ are bound to fresh locations, the values of
+the arguments are stored in those locations, the _`<body>`_ is evaluated in
+the extended environment, and the results of _`<body>`_ are returned as the
+results of the procedure call. It is an error for the arguments not to
+match with the _`<pattern>`_ of any _`<clause>`_.
 
-An identifier appearing within a _<pattern>_ can be an underscore (`_`), a 
-literal identifier listed in the list of _<pattern-literal>_. All other 
-identifiers appearing within a _<pattern>_ are variables.
+An identifier appearing within a _`<pattern>`_ can be an underscore (`_`),
+a literal identifier listed in the list of _`<pattern-literal>`_. All other
+identifiers appearing within a _`<pattern>`_ are variables.
 
-Variables in _<pattern>_ match arbitrary input elements and are used to refer 
-to elements of the input in the body. It is an error for the same variable 
-to appear more than once in a _<pattern>_. Underscores also match arbitrary 
-input elements but are not variables and so cannot be used to refer to those 
-elements. If an underscore appears in the _<pattern literal>_ list, then that 
-takes precedence and underscores in the _<pattern>_ match as literals. Multiple 
-underscores can appear in a _<pattern>_.
+Variables in _`<pattern>`_ match arbitrary input elements and are used to
+refer to elements of the input in the body. It is an error for the same
+variable to appear more than once in a _`<pattern>`_. Underscores also
+match arbitrary input elements but are not variables and so cannot be used
+to refer to those elements. If an underscore appears in the _`<pattern
+literal>`_ list, then that takes precedence and underscores in the
+_`<pattern>`_ match as literals.  Multiple underscores can appear in a
+_`<pattern>`_.
 
-Identifiers that appear in (_<pattern literal>_ ...) are interpreted as literal 
-identifiers to be matched against corresponding elements of the input. An 
-element in the input matches a literal identifiers if and only if it is an 
-symbol and equal to literal identifier in the sense of the eqv? procedure.
+Identifiers that appear in `(_<pattern literal>`_ ...)` are interpreted as
+literal identifiers to be matched against corresponding elements of the
+input.  An element in the input matches a literal identifiers if and only
+if it is an symbol and equal to literal identifier in the sense of the
+`eqv?` procedure.
 
 ## License
 
 Copyright (c) 2014 SAITO Atsushi
 
-Redistribution and use in source and binary forms, with or without 
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, 
@@ -97,15 +101,15 @@ modification, are permitted provided that the following conditions are met:
    used to endorse or promote products derived from this software without 
    specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-ARE DISCLAIMED.
-IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY 
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
 

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,32 @@ This package doesn't contain install scripts.  The installation procedure
 depends on the Scheme implementation you're using.  Please see document of
 the implementation.
 
+## How to use
+
+The following examples shows how to use `pattern-match-lambda`.
+
+```scheme
+(define fact
+  (pattern-match-lambda ()
+   ((0) 1)
+   ((n) (* n (fact (- n 1))))))
+
+(fact 5) ;; -> 120
+
+(define string-input?
+  (pattern-match-lambda ()
+    ((x) (string? x) x)
+    ((x) 'not-string)))
+
+(string-input? "ok") ;; -> "ok"
+(string-input? 'ng)  ;; ->  not-string
+```
+
+[test.scm](test.scm) contains more examples.
+
 ## Syntax
-A `pattern-match-lambda`'s syntax is the following.
+
+The `pattern-match-lambda`'s syntax is the following.
 
 ```scheme
 (pattern-match-lambda (<pattern literal> ...) <clause> ...)
@@ -54,7 +78,7 @@ variable number of arguments and is lexically scoped in the same manner as
 a procedure resulting from a lambda expression. When the procedure is
 called, the first _`<clause>`_ for which the arguments match with
 _`<pattern>`_ is selected, where argument is specified as for the
-_`<pattern>`_ of a syntax-rules like expression.
+_`<pattern>`_ of a `syntax-rules` like expression.
 
 Difference between _`<pattern>`_ of `syntax-rules` and
 `pattern-match-lambda` is ellipsis. Ellipsis is not able to use in

--- a/readme.md
+++ b/readme.md
@@ -85,8 +85,8 @@ Difference between _`<pattern>`_ of `syntax-rules` and
 pattern-match-lambda's _`<pattern>`_.
 
 The variables of _`<pattern>`_ are bound to fresh locations, the values of
-the arguments are stored in those locations, the _`<body>`_ is evaluated in
-the extended environment, and the results of _`<body>`_ are returned as the
+the arguments are stored in those locations, the _`<expr>`_ is evaluated in
+the extended environment, and the results of _`<expr>`_ are returned as the
 results of the procedure call. It is an error for the arguments not to
 match with the _`<pattern>`_ of any _`<clause>`_.
 

--- a/readme.md
+++ b/readme.md
@@ -3,30 +3,27 @@
 ## Introduction
 
 This package is easy pattern match library for R7RS.
-It provide a macro pattern-match-lambda only one.
+It provides only one macro named `pattern-match-lambda`.
 
 ## Install
 
-This package don't contain install script.
-How to install depends on each Scheme implementation.
-Please see document of each Scheme implementation.
+This package doesn't contain install scripts.
+The installation procedure depends on the Scheme implementation you're using.
+Please see document of the implementation.
 
 ## Syntax
-A pattern-match-lambda's syntax is following.
+A `pattern-match-lambda`'s syntax is the following.
 
 ```scheme
 (pattern-match-lambda (<pattern literal> ...) <clause> ...)
 ```
 
-Each &lt;clause&gt; is of the form (&lt;pattern&gt; &lt;body&gt;), where &lt;pattern&gt; and &lt;body&gt; have the syntax that be similar to syntax-rules.
+<clause> must have one of the following forms:
 
-It is an error if &lt;clause&gt; is not of the form
-```scheme
-(<pattern> <body>)
-```
-The &lt;pattern&gt; in a &lt;clause&gt; is a list &lt;pattern&gt;.
+- ```(<pattern> <expr>)```
+- ```(<pattern> <fender> <expr>)```
 
-A &lt;pattern&gt; is either an identifier, a constant, or one of the following.
+A <pattern> is either an identifier, a constant, or one of the followings.
 
 ```scheme
 (<pattern> ...)
@@ -34,30 +31,81 @@ A &lt;pattern&gt; is either an identifier, a constant, or one of the following.
 #(<pattern> ...)
 ```
 
+A <fender> is an expression which is evaluated when <pattern> is matched.
+If the result of evaluation is true value, then the following <expr> is
+evaluated, otherwise `pattern-match-lambda` continues matching. The following
+example shows how it works:
+
+```scheme
+(define foo
+  (pattern-match-lambda ()
+    ((a) (eq? a 'fender) 'fender)
+    ((a) 'fallback)))
+
+(foo 'fender) ;; -> fender
+(foo 'a)      ;; -> fallback
+```
+
 ## Semantics
 
-A pattern-match-lambda expression evaluates to a procedure that accepts a variable number of arguments and is lexically scoped in the same manner as a procedure resulting from a lambda expression. When the procedure is called, the first &lt;clause&gt; for which the arguments match with &lt;pattern&gt; is selected, where argument is specified as for the &lt;pattern&gt; of a syntax-rules like expression.
+A `pattern-match-lambda` expression evaluates to a procedure that accepts a
+variable number of arguments and is lexically scoped in the same manner as 
+a procedure resulting from a lambda expression. When the procedure is called,
+the first <clause> for which the arguments match with <pattern> is selected, 
+where argument is specified as for the <pattern> of a syntax-rules like 
+expression.
 
-Difference between &lt;pattern&gt; of syntax-rules and pattern-match-lambda is ellipsis. Ellipsis is not able to use in pattern-match-lambda's &lt;pattern&gt;.
+Difference between <pattern> of `syntax-rules` and `pattern-match-lambda` is 
+ellipsis. Ellipsis is not able to use in pattern-match-lambda's <pattern>.
 
-The variables of &lt;pattern&gt; are bound to fresh locations, the values of the arguments are stored in those locations, the &lt;body&gt; is evaluated in the extended environment, and the results of &lt;body&gt; are returned as the results of the procedure call. It is an error for the arguments not to match with the &lt;pattern&gt; of any &lt;clause&gt;.
+The variables of <pattern> are bound to fresh locations, the values of the 
+arguments are stored in those locations, the <body> is evaluated in the 
+extended environment, and the results of <body> are returned as the results 
+of the procedure call. It is an error for the arguments not to match with 
+the <pattern> of any <clause>.
 
-An identifierappearing within a &lt;pattern&gt; can be an underscore (_), a literal identifier listed in the list of &lt;pattern-literal&gt;. All other identifiers appearing within a &lt;pattern&gt; are variables.
+An identifier appearing within a <pattern> can be an underscore (`_`), a 
+literal identifier listed in the list of <pattern-literal>. All other 
+identifiers appearing within a <pattern> are variables.
 
-Variables in &lt;pattern&gt; match arbitrary input elements and are used to refer to elements of the input in the body. It is an error for the same variable to appear more than once in a &lt;pattern&gt;. Underscores also match arbitrary input elements but are not variables and so cannot be used to refer to those elements. If an underscore appears in the &lt;pattern literal&gt; list, then that takes precedence and underscores in the &lt;pattern&gt; match as literals. Multiple underscores can appear in a &lt;pattern&gt;.
+Variables in <pattern> match arbitrary input elements and are used to refer 
+to elements of the input in the body. It is an error for the same variable 
+to appear more than once in a <pattern>. Underscores also match arbitrary 
+input elements but are not variables and so cannot be used to refer to those 
+elements. If an underscore appears in the <pattern literal> list, then that 
+takes precedence and underscores in the <pattern> match as literals. Multiple 
+underscores can appear in a <pattern>.
 
-Identifiers that appear in (&lt;pattern literal&gt; ...) are interpreted as literal identifiersto be matched against corresponding elements of the input. An element in the input matches a literal identifiers if and only if it is an symbol and equal to literal identifier in the sense of the eqv? procedure.
+Identifiers that appear in (<pattern literal> ...) are interpreted as literal 
+identifiers to be matched against corresponding elements of the input. An 
+element in the input matches a literal identifiers if and only if it is an 
+symbol and equal to literal identifier in the sense of the eqv? procedure.
 
 ## License
 
 Copyright (c) 2014 SAITO Atsushi
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-3. Neither the name of the authors nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+1. Redistributions of source code must retain the above copyright notice, 
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions and the following disclaimer in the documentation 
+   and/or other materials provided with the distribution.
+3. Neither the name of the authors nor the names of its contributors may be 
+   used to endorse or promote products derived from this software without 
+   specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY 
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 


### PR DESCRIPTION
変更の要約
- `<fender>`の説明の追加
- 簡単な使用例の追加
- `<pattern literal ...>`の説明の追加
- HTMLエスケープの排除(編集時に面倒だったので・・・)

Semanticsの章が堅苦しいかなぁと思うので、特に第三パラグラフの変数の格納場所の部分、マッチングルールの記述のみに抑えてもいいかなぁと思いました。(別にPR出すかもしれません)
